### PR TITLE
add PushInterface.jl, update node-ableton-push2 to ableton-push2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Please add an [issue](https://github.com/Ableton/push-interface/issues) with you
 * https://github.com/Ableton/push2-display-with-juce                      
 
 * https://github.com/brunchboy/wayang
-* https://www.npmjs.com/package/node-ableton-push2
+* https://www.npmjs.com/package/ableton-push2
 * https://github.com/net147/Push2Qml
 * http://sigabort.co/p2d
 * https://github.com/garrensmith/abletonpush
+* https://github.com/wookay/PushInterface.jl
 
   Please Note: The external links are being provided as a convenience and for informational purposes only. They do not constitute an endorsement or an approval by the Ableton of any of the linked contents. Ableton bears no responsibility for the accuracy, legality or
   the content of the referred site or for that of subsequent links.


### PR DESCRIPTION
Hello,
I'm also adding the link - PushInterface.jl - a Julia library for Ableton Push 2 Interface.
and update the deprecated node-ableton-push2 nodejs package to moved one.