### PR TITLE
Fix #28: Add 'yes' to 'Sends Reply' column for Get Display Brightness command

### DIFF
--- a/doc/AbletonPush2MIDIDisplayInterface.asc
+++ b/doc/AbletonPush2MIDIDisplayInterface.asc
@@ -240,7 +240,7 @@ arguments are avoided.
 |+0x06+ | |Set LED Brightness .2+|<<Global LED Brightness>>
 |+0x07+ |yes|Get LED Brightness
 |+0x08+ | |Set Display Brightness .2+|<<Display Backlight>>
-|+0x09+ | |Get Display Brightness
+|+0x09+ |yes|Get Display Brightness .2+|<<Display Backlight>>
 |+0x0A+ |yes|Set MIDI Mode |<<MIDI Mode>>
 |+0x0B+ | |Set LED PWM Frequency Correction |<<PWM Frequency>>
 |+0x13+ |yes|Sample Pedal Data |<<Pedal Sampling>>


### PR DESCRIPTION
Fixes issue #28: Possible typo at "2.4.2 Command List"

The command list table incorrectly showed that Get Display Brightness (0x09)
does not send a reply. This commit fixes the table to correctly indicate
that the command does send a reply, matching the command description.

**Changes:**
- Added "yes" to "Sends Reply" column for command 0x09
- Added chapter reference for consistency

**Files Changed:**
- doc/AbletonPush2MIDIDisplayInterface.asc

Ready for squash-and-merge.