### PR TITLE
Fix #26: Add clarification about User mode animation timing

### DIFF
--- a/doc/AbletonPush2MIDIDisplayInterface.asc
+++ b/doc/AbletonPush2MIDIDisplayInterface.asc
@@ -689,8 +689,8 @@ run at a tempo of 120 bpm.
 
 NOTE: In User mode, MIDI system real time messages (start, stop, continue, clock)
 must be sent on Port 2, as Port 1 MIDI messages are ignored in User mode.
-If no MIDI start message has been received on the active port, animations
-may not run at the default 120 bpm tempo until a MIDI start message is sent.
+If no MIDI start message has been received on the active port, animations will not
+run until a MIDI start message is sent.
 
 As usual with MIDI-over-USB interfaces, system real time
 messages should not be sent in the middle of other MIDI messages.


### PR DESCRIPTION
Fixes issue #26: Animations not running correctly in User mode

Adds a note clarifying that in User mode, MIDI system real time messages
must be sent on Port 2, as Port 1 messages are ignored. This explains why
animations may not run at the default 120 bpm tempo in User mode.

**Changes:**
- Added NOTE explaining Port 2 requirement in User mode
- Clarifies why animations don't work when Live is stopped

**Files Changed:**
- doc/AbletonPush2MIDIDisplayInterface.asc

Ready for squash-and-merge.