### PR TITLE
Fix #22: Add documentation for converting RGB values to color palette indices

### DIFF
--- a/doc/AbletonPush2MIDIDisplayInterface.asc
+++ b/doc/AbletonPush2MIDIDisplayInterface.asc
@@ -441,6 +441,29 @@ Reply: ++[F0 00 21 1D 01 01 **04 7D 00 00 00 00 7F 01 7E 00** F7]++ = entry 125 
 6+|Example: ++[F0 00 21 1D 01 01 **05** F7]++ = trigger palette reapplication
 |===
 
+Converting RGB Values to Color Palette Indices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Push 2 LEDs do not accept direct RGB values. Colors must be specified using
+color palette indices (0-127). To convert an arbitrary RGB color to the closest
+available palette index:
+
+1. Retrieve the complete color palette by querying all 128 entries (0-127)
+   using the "Get LED Color Palette Entry" command (0x04).
+
+2. For each palette entry, calculate the distance between your target RGB
+   color and the palette entry's RGB values. Common distance metrics include:
+   - Euclidean distance in RGB space: sqrt((R1-R2)² + (G1-G2)² + (B1-B2)²)
+   - Perceptual color distance (e.g., using LAB color space) for better
+     visual matching
+
+3. Select the palette index with the minimum distance.
+
+Alternatively, you can modify the palette to add custom colors by using the
+"Set LED Color Palette Entry" command (0x03) to overwrite existing palette
+entries with your desired RGB values. After modifying palette entries, send
+the "Reapply Color Palette" command (0x05) to apply the changes.
+
 White LED Color Processing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/AbletonPush2MIDIDisplayInterface.asc
+++ b/doc/AbletonPush2MIDIDisplayInterface.asc
@@ -453,7 +453,7 @@ available palette index:
 
 2. For each palette entry, calculate the distance between your target RGB
    color and the palette entry's RGB values. Common distance metrics include:
-   - Euclidean distance in RGB space: sqrt((R1-R2)² + (G1-G2)² + (B1-B2)²)
+   - Euclidean distance in RGB space: sqrt((R1-R2)^2 + (G1-G2)^2 + (B1-B2)^2)
    - Perceptual color distance (e.g., using LAB color space) for better
      visual matching
 

--- a/doc/AbletonPush2MIDIDisplayInterface.asc
+++ b/doc/AbletonPush2MIDIDisplayInterface.asc
@@ -454,9 +454,12 @@ available palette index:
 2. For each palette entry, calculate the distance between your target RGB
    color and the palette entry's RGB values. Common distance metrics include:
    - Euclidean distance in RGB space: sqrt((R1-R2)^2 + (G1-G2)^2 + (B1-B2)^2)
-   - Perceptual color distance (e.g., using LAB color space) for better
-     visual matching
+   - Perceptual color distance (e.g., using CIE L*a*b* (CIELAB) color space
+     and a ΔE formula) for better visual matching
 
+   Perceptual distance in CIELAB is recommended when matching colors based on
+   how similar they appear to the human eye, while simple Euclidean distance
+   in RGB space can be sufficient for rough or performance-critical matching.
 3. Select the palette index with the minimum distance.
 
 Alternatively, you can modify the palette to add custom colors by using the


### PR DESCRIPTION
Fixes issue #22: How to translate Max For Live colors to Palette Color Index?

Adds a new section explaining how to convert arbitrary RGB color values to
the closest Push 2 color palette index.

**Changes:**
- Added section "Converting RGB Values to Color Palette Indices"
- Step-by-step algorithm with distance calculation methods
- Includes Euclidean and LAB color space methods

**Files Changed:**
- doc/AbletonPush2MIDIDisplayInterface.asc

Ready for squash-and-merge.